### PR TITLE
Proposed fix for reap-cycle cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ PumaAutoTune.config do |config|
 end
 ```
 
-To see defaults check out [puma_auto_tune.rb](lib/puma_auto_tune/puma_auto_tune.rb)
+To see defaults check out [puma_auto_tune.rb](lib/puma_auto_tune.rb)
 
 
 ## Hitting the Sweet Spot

--- a/lib/puma_auto_tune/master.rb
+++ b/lib/puma_auto_tune/master.rb
@@ -43,7 +43,7 @@ module PumaAutoTune
     # to persist.
     def cached_wrapped_worker(puma_worker)
       @worker_cache ||= {}
-      @worker_cache.fetch(puma_worker.pid) { PumaAutoTune::Worker.new(puma_worker) }
+      @worker_cache[puma_worker.pid] ||= PumaAutoTune::Worker.new(puma_worker)
     end
 
     def get_master

--- a/lib/puma_auto_tune/master.rb
+++ b/lib/puma_auto_tune/master.rb
@@ -1,6 +1,6 @@
 module PumaAutoTune
   class Master
-  def initialize(master = nil)
+    def initialize(master = nil)
       @master = master || get_master
     end
 
@@ -33,13 +33,21 @@ module PumaAutoTune
     end
 
     def workers
-      @master.instance_variable_get("@workers").map {|w| PumaAutoTune::Worker.new(w) }
+      @master.instance_variable_get("@workers").map {|w| cached_wrapped_worker(w) }
     end
 
     private
 
+    # Always returns an existing PumaAutoTune::Worker instance if we have
+    # seen this puma_worker (by its pid). This allows the restarting flag
+    # to persist.
+    def cached_wrapped_worker(puma_worker)
+      @worker_cache ||= {}
+      @worker_cache.fetch(puma_worker.pid) { PumaAutoTune::Worker.new(puma_worker) }
+    end
+
     def get_master
-      ObjectSpace.each_object(Puma::Cluster).map { |obj| obj }.first if defined?(Puma::Cluster)
+      ObjectSpace.each_object(Puma::Cluster).first if defined?(Puma::Cluster)
     end
   end
 end

--- a/lib/puma_auto_tune/memory.rb
+++ b/lib/puma_auto_tune/memory.rb
@@ -34,7 +34,7 @@ module PumaAutoTune
 
     def reset
       raise "must set master" unless @master
-      @workers.map {|w| w.reset_memory }
+      @workers.map {|w| w.reset_memory } unless @workers.nil?
       @workers      = nil
       @mb           = nil
     end

--- a/lib/puma_auto_tune/memory.rb
+++ b/lib/puma_auto_tune/memory.rb
@@ -29,11 +29,12 @@ module PumaAutoTune
     end
 
     def workers
-      workers ||= @master.workers.sort_by! {|w| w.get_memory }
+      @workers ||= @master.workers.sort_by! {|w| w.get_memory }
     end
 
     def reset
       raise "must set master" unless @master
+      @workers.map {|w| w.reset_memory }
       @workers      = nil
       @mb           = nil
     end

--- a/lib/puma_auto_tune/memory.rb
+++ b/lib/puma_auto_tune/memory.rb
@@ -15,8 +15,7 @@ module PumaAutoTune
 
     def amount
       @mb ||= begin
-        worker_memory = workers.map {|w| w.memory }.inject(&:+) || 0
-        worker_memory + @master.get_memory
+        worker_memory + master_memory
       end
     end
 
@@ -37,6 +36,14 @@ module PumaAutoTune
       @workers.map {|w| w.reset_memory } unless @workers.nil?
       @workers      = nil
       @mb           = nil
+    end
+
+    def worker_memory
+      workers.map {|w| w.memory }.inject(&:+) || 0
+    end
+
+    def master_memory
+      @master.get_memory
     end
   end
 end

--- a/lib/puma_auto_tune/worker.rb
+++ b/lib/puma_auto_tune/worker.rb
@@ -18,6 +18,14 @@ module PumaAutoTune
       end
     end
 
+    def reset_memory
+      # Reset memory so we recalculate how much we're using.
+      # This also allows subsequent calls to #memory to call
+      # into #get_memory which will start returning 0 when
+      # this worker is restarting.
+      @memory = nil
+    end
+
     def restarting?
       @restarting
     end


### PR DESCRIPTION
Added in a cache for our wrapped Puma::Worker objects so that whenever
we call PumaAutoTune::Master#workers we will always get the same
PumaAutoTune::Worker objects. This lets the concept of restarting a
worker persist through calls to reset on PumaAutoTune::Memory. We want
resetting the memory to recalculate the memory EXCEPT for the fact that
we want the restarting worker to still return 0.

This is a proposed fix for the problem outlined in schneems/puma_auto_tune#10
