### PR TITLE
Fix worker growth to actually check est. memory

### DIFF
--- a/lib/puma_auto_tune/defaults/ram/hooks.rb
+++ b/lib/puma_auto_tune/defaults/ram/hooks.rb
@@ -4,8 +4,8 @@ PumaAutoTune.hooks(:ram) do |auto|
   auto.set(:cycle) do |memory, master, workers|
     if memory > PumaAutoTune.ram # mb
       auto.call(:out_of_memory)
-    else
-      auto.call(:under_memory) if memory + workers.last.memory
+    elsif memory + workers.last.memory <= PumaAutoTune.ram
+      auto.call(:under_memory)
     end
   end
 


### PR DESCRIPTION
I believe that `:cycle` was always intended to grow workers by calling
:under_memory if the estimate of how much memory we would use by adding
a worker is safe given constraints of PumaAutoTune.ram. The existing
`if` check in :cycle did not actually check anything I don't
believe.
