### PR TITLE
Auto Detect Heroku Dyno Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ PumaAutoTune.config do |config|
 end
 ```
 
-The default is `512` which matches the amount of ram available on a Heroku dyno. There are a few other advanced config options:
+We will attempt to detect your RAM size if you are running on Heroku. If we cannot, the default is `512` mb. There are a few other advanced config options:
 
 ```ruby
 PumaAutoTune.config do |config|

--- a/bin/heroku_ulimit_to_ram
+++ b/bin/heroku_ulimit_to_ram
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+limit=$(ulimit -u)
+
+case $limit in
+256)
+  ram=512
+  ;;
+512)
+  ram=1024
+  ;;
+32768)
+  ram=8192
+  ;;
+*)
+  echo 'nope';
+  exit 1;
+  ;;
+esac
+
+echo $ram

--- a/lib/puma_auto_tune.rb
+++ b/lib/puma_auto_tune.rb
@@ -14,8 +14,19 @@ module PumaAutoTune
 
   extend self
 
+  def self.default_ram
+    result = `bin/heroku_ulimit_to_ram`
+    default = if $?.success?
+      Integer(result)
+    else
+      512
+    end
+    puts "Default RAM set to #{default}"
+    default
+  end
+
   attr_accessor :ram, :max_worker_limit, :frequency, :reap_duration
-  self.ram                = 512  # mb
+  self.ram                = self.default_ram  # mb
   self.max_worker_limit   = INFINITY
   self.frequency          = 10 # seconds
   self.reap_duration      = 90 # seconds


### PR DESCRIPTION
If you're on Heroku and you're not manually setting your RAM size, we'll now automagically set the RAM value to the right number. This is an experimental feature.
