### PR TITLE
Detect possible RAM by Ruby and just use `ulimit` command

### DIFF
--- a/lib/puma_auto_tune.rb
+++ b/lib/puma_auto_tune.rb
@@ -15,12 +15,26 @@ module PumaAutoTune
   extend self
 
   def self.default_ram
-    result = `bin/heroku_ulimit_to_ram`
-    default = if $?.success?
-      Integer(result)
-    else
-      512
-    end
+    ulimit = `ulimit -u`
+    ulimit = if $?.success?
+               ulimit.chomp.to_i
+             else
+               nil
+             end
+
+    result = case ulimit
+             when 256
+               512
+             when 512
+               1024
+             when 32768
+               8192
+             else
+               nil
+             end
+
+    default = result || 512
+
     puts "Default RAM set to #{default}"
     default
   end


### PR DESCRIPTION
- Right now the bin script is not getting executed because its getting
  confused by the path.
- Found out this while upgrading codetriage that while running rake
  tasks it gives error:
  
  Errno::ENOENT: No such file or directory - bin/heroku_ulimit_to_ram
- It is not able to resolve the path to the script.
- This fix will only use `ulimit` command and perform rest of the job in Ruby.
