### PR TITLE
Use relative path for heroku_ulimit_to_ram

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,5 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.1
-  - ruby-head
-  - jruby-19mode
-  - rbx-19mode
-
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: rbx-19mode
-    - rvm: jruby-19mode
+  - 2.2.9
+  - 2.5.3

--- a/lib/puma_auto_tune.rb
+++ b/lib/puma_auto_tune.rb
@@ -16,7 +16,7 @@ module PumaAutoTune
   extend self
 
   def self.default_ram
-    result = system(HEROKU_ULIMIT_TO_RAM_PATH)
+    result = `#{HEROKU_ULIMIT_TO_RAM_PATH}`
     default = if $?.success?
       Integer(result)
     else

--- a/lib/puma_auto_tune.rb
+++ b/lib/puma_auto_tune.rb
@@ -11,11 +11,12 @@ require 'puma_auto_tune/memory'
 module PumaAutoTune
   INFINITY    = 1/0.0
   RESOURCES = { ram: PumaAutoTune::Memory.new }
+  HEROKU_ULIMIT_TO_RAM_PATH = File.expand_path('../../bin/heroku_ulimit_to_ram', __FILE__)
 
   extend self
 
   def self.default_ram
-    result = `bin/heroku_ulimit_to_ram`
+    result = system(HEROKU_ULIMIT_TO_RAM_PATH)
     default = if $?.success?
       Integer(result)
     else

--- a/lib/puma_auto_tune/master.rb
+++ b/lib/puma_auto_tune/master.rb
@@ -1,6 +1,6 @@
 module PumaAutoTune
   class Master
-  def initialize(master = nil)
+    def initialize(master = nil)
       @master = master || get_master
     end
 
@@ -11,9 +11,11 @@ module PumaAutoTune
     # https://github.com/puma/puma/blob/master/docs/signals.md#puma-signals
     def remove_worker
       previous_worker_count = workers.size
+
+      send_signal("TTOU")
+
       until workers.size < previous_worker_count
-        send_signal("TTOU")
-        sleep 1
+        sleep 0.1
       end
     end
 

--- a/lib/puma_auto_tune/worker.rb
+++ b/lib/puma_auto_tune/worker.rb
@@ -12,17 +12,14 @@ module PumaAutoTune
     alias :mb :memory
 
     def get_memory
-      @memory = if restarting?
-        0
-      else
-        ::GetProcessMem.new(self.pid).mb
-      end
+      return 0 if restarting?
+
+      @memory = ::GetProcessMem.new(self.pid).mb
     end
 
     def restarting?
       @restarting
     end
-
 
     def restart
       @restarting = true

--- a/test/puma_auto_tune_test.rb
+++ b/test/puma_auto_tune_test.rb
@@ -25,11 +25,12 @@ class PumaAutoTuneTest < Test::Unit::TestCase
     @puma.wait
 
     assert @puma.wait %r{current_cluster_size=1}
-    assert_match "max_worker_limit=3",     @puma.log.read
-    assert_match "max_worker_limit=2",     @puma.log.read
-    assert_match "max_worker_limit=1",     @puma.log.read
+
+    assert_match /max_worker_limit=3/,     @puma.log.read
+    assert_match /max_worker_limit=2/,     @puma.log.read
+    assert_match /max_worker_limit=1/,     @puma.log.read
     # refute
-    refute_match "max_worker_limit=0",     @puma.log.read
+    refute_match /max_worker_limit=0/,     @puma.log.read
   end
 
   def test_increment_workers

--- a/test/puma_auto_tune_test.rb
+++ b/test/puma_auto_tune_test.rb
@@ -24,13 +24,13 @@ class PumaAutoTuneTest < Test::Unit::TestCase
     @puma = PumaRemote.new(ram: 1, puma_workers: 5).spawn
     @puma.wait
 
+    assert @puma.wait %r{current_cluster_size=5}
+    assert @puma.wait %r{current_cluster_size=4}
+    assert @puma.wait %r{current_cluster_size=3}
+    assert @puma.wait %r{current_cluster_size=2}
     assert @puma.wait %r{current_cluster_size=1}
 
-    assert_match /max_worker_limit=3/,     @puma.log.read
-    assert_match /max_worker_limit=2/,     @puma.log.read
-    assert_match /max_worker_limit=1/,     @puma.log.read
-    # refute
-    refute_match /max_worker_limit=0/,     @puma.log.read
+    refute_match /max_worker_limit=0/, @puma.log.read
   end
 
   def test_increment_workers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 Bundler.require
 
 require 'test/unit'
+require 'timeout'
 
 class PumaRemote
 


### PR DESCRIPTION
Solves file not found problem.

```
rake aborted!
Errno::ENOENT: No such file or directory - bin/heroku_ulimit_to_ram
/home/rof/cache/bundler/ruby/2.5.0/bundler/gems/puma_auto_tune-0942cee51df1/lib/puma_auto_tune.rb:18:in ``'
/home/rof/cache/bundler/ruby/2.5.0/bundler/gems/puma_auto_tune-0942cee51df1/lib/puma_auto_tune.rb:18:in `default_ram'
/home/rof/cache/bundler/ruby/2.5.0/bundler/gems/puma_auto_tune-0942cee51df1/lib/puma_auto_tune.rb:29:in `<module:PumaAutoTune>'
/home/rof/cache/bundler/ruby/2.5.0/bundler/gems/puma_auto_tune-0942cee51df1/lib/puma_auto_tune.rb:11:in `<top (required)>'
```
